### PR TITLE
Fix auth password bug, add mqtt password set, schedules

### DIFF
--- a/plugins/modules/auth.py
+++ b/plugins/modules/auth.py
@@ -55,7 +55,7 @@ def run_module():
         argument_spec=module_args,
         supports_check_mode=True,
         required_if=[
-            ("enable", True, ("password"), False)
+            ("enable", True, ("password",), False)
         ]
     )
 

--- a/plugins/modules/mqtt.py
+++ b/plugins/modules/mqtt.py
@@ -165,14 +165,20 @@ def run_module():
 
     new_config = current_config.copy()
     for key, current_value in current_config.items():
-        # 'pass' is a reserved word — module param is 'password', API field is 'pass'
-        param_key = "password" if key == "pass" else key
-        if param_key not in module.params or module.params[param_key] is None:
+        # Skip 'pass' here — handled separately below since GetConfig never returns the actual value
+        if key == "pass":
+            continue
+        if key not in module.params or module.params[key] is None:
             continue
 
-        if module.params[param_key] != current_value:
-            new_config[key] = module.params[param_key]
+        if module.params[key] != current_value:
+            new_config[key] = module.params[key]
             result["changed"] = True
+
+    # Password is always set if provided — GetConfig returns null so we can't diff it
+    if module.params.get("password") is not None:
+        new_config["pass"] = module.params["password"]
+        result["changed"] = True
 
     if module.check_mode:
         if result["changed"]:

--- a/plugins/modules/mqtt.py
+++ b/plugins/modules/mqtt.py
@@ -128,6 +128,7 @@ def run_module():
         server=dict(type="str", required=False),
         client_id=dict(type="str", required=False),
         user=dict(type="str", required=False),
+        password=dict(type="str", required=False, no_log=True),
         ssl_ca=dict(type="str", required=False, choices=["none", "*", "user_ca.pem", "ca.pem"]),
         topic_prefix=dict(type="str", required=False),
         rpc_ntf=dict(type="bool", required=False, default=True),
@@ -164,11 +165,13 @@ def run_module():
 
     new_config = current_config.copy()
     for key, current_value in current_config.items():
-        if not key in module.params:
+        # 'pass' is a reserved word — module param is 'password', API field is 'pass'
+        param_key = "password" if key == "pass" else key
+        if param_key not in module.params or module.params[param_key] is None:
             continue
 
-        if module.params[key] != current_value:
-            new_config[key] = module.params[key]
+        if module.params[param_key] != current_value:
+            new_config[key] = module.params[param_key]
             result["changed"] = True
 
     if module.check_mode:

--- a/plugins/modules/schedule.py
+++ b/plugins/modules/schedule.py
@@ -1,0 +1,144 @@
+#!/usr/bin/python
+
+DOCUMENTATION = '''
+---
+module: schedule
+short_description: Manage scheduled jobs on a Shelly gen 2+ device.
+version_added: "0.0.1"
+description:
+  - Create or delete scheduled jobs on a Shelly gen 2+ device.
+  - Matches existing jobs by timespec + method + params combination for idempotency.
+options:
+    timespec:
+        description:
+          - 6-field cron expression (seconds minute hour dom month dow).
+          - Required when state is present.
+        required: false
+        type: str
+    method:
+        description:
+          - RPC method to call on schedule (e.g. "Script.Start").
+          - Required when state is present.
+        required: false
+        type: str
+    params:
+        description:
+          - Parameters to pass to the RPC method.
+        required: false
+        type: dict
+        default: {}
+    enable:
+        description:
+          - Whether the schedule is enabled.
+        required: false
+        type: bool
+        default: true
+    state:
+        description:
+          - present - create schedule if not already matching.
+          - absent - delete all matching schedules.
+        required: true
+        type: str
+        choices: ["present", "absent"]
+author:
+    - Alastair McFarlane
+'''
+
+EXAMPLES = '''
+- name: Run fallback script every 30 seconds
+  enclave.shelly.schedule:
+    timespec: "0,30 * * * * *"
+    method: Script.Start
+    params:
+      id: 2
+    enable: true
+    state: present
+'''
+
+RETURN = '''
+schedule_id:
+  description: ID of the created or matched schedule.
+  type: int
+  returned: when state is present
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+
+
+def jobs_match(job, timespec, method, params):
+    if job.get("timespec") != timespec:
+        return False
+    calls = job.get("calls", [])
+    if not calls:
+        return False
+    call = calls[0]
+    return call.get("method") == method and call.get("params", {}) == params
+
+
+def run_module():
+    module_args = dict(
+        timespec=dict(type="str", required=False),
+        method=dict(type="str", required=False),
+        params=dict(type="dict", required=False, default={}),
+        enable=dict(type="bool", required=False, default=True),
+        state=dict(type="str", required=True, choices=["present", "absent"]),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("timespec", "method")),
+        ]
+    )
+
+    result = dict(changed=False)
+    connection = Connection(module._socket_path)
+
+    existing = connection.send_request(data={"method": "Schedule.List"})
+    jobs = existing.get("jobs", [])
+
+    timespec = module.params["timespec"]
+    method = module.params["method"]
+    params = module.params["params"]
+    enable = module.params["enable"]
+    state = module.params["state"]
+
+    matching = [j for j in jobs if jobs_match(j, timespec, method, params)]
+
+    if state == "absent":
+        if not matching:
+            module.exit_json(**result)
+        if not module.check_mode:
+            for job in matching:
+                connection.send_request(data={"method": "Schedule.Delete", "params": {"id": job["id"]}})
+        result["changed"] = True
+        module.exit_json(**result)
+
+    # state == present
+    if matching:
+        result["schedule_id"] = matching[0]["id"]
+        module.exit_json(**result)
+
+    if not module.check_mode:
+        created = connection.send_request(data={
+            "method": "Schedule.Create",
+            "params": {
+                "timespec": timespec,
+                "enable": enable,
+                "calls": [{"method": method, "params": params}],
+            }
+        })
+        result["schedule_id"] = created.get("id")
+
+    result["changed"] = True
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/script.py
+++ b/plugins/modules/script.py
@@ -285,6 +285,8 @@ def run_module():
             result["restart_required"] = set_script_enable(current_script_state, module.params["enable"], connection)
 
     result["changed"] = changed
+    if current_script_state is not None:
+        result["script_id"] = current_script_state.id
     module.exit_json(**result)
 
 


### PR DESCRIPTION
There was a bug with setting a web auth password string vs tuple, and mqtt only supported properties which it could read out of GetConfig - but password is never returned. Added a module to manage schedules and (because I needed it for a schedule), return the script ID on creating one